### PR TITLE
Prepare for generics-sop-0.2.

### DIFF
--- a/exhaustive.cabal
+++ b/exhaustive.cabal
@@ -21,7 +21,7 @@ library
   exposed-modules:     Control.Exhaustive
   -- other-modules:
   other-extensions:    ConstraintKinds, FlexibleContexts, FlexibleInstances, FunctionalDependencies, GADTs, RankNTypes, ScopedTypeVariables, TypeFamilies, TypeOperators, UndecidableInstances
-  build-depends:       base >=4.7 && <4.9, generics-sop >=0.1 && <0.2, transformers >=0.3 && <0.5, template-haskell
+  build-depends:       base >=4.7 && <4.9, generics-sop >=0.1 && <0.3, transformers >=0.3 && <0.5, template-haskell
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options: -Wall

--- a/src/Control/Exhaustive.hs
+++ b/src/Control/Exhaustive.hs
@@ -283,7 +283,7 @@ finish = Nil
 -- first constructor to successfully be constructed (in the order defined in the
 -- original data type) will be returned, or 'empty' if all constructions fail.
 produceFirst
-  :: (code ~ Code a, SingI code, Generic a, Alternative f)
+  :: (code ~ Code a, Generic a, Alternative f)
   => NP (ConstructorApplication f code) code -> f a
 produceFirst = asum . produceM
 
@@ -291,13 +291,13 @@ produceFirst = asum . produceM
 -- fail, they will not be included in the resulting list. If all constructors
 -- fail, this will return 'pure' @[]@.
 produceAll
-  :: (code ~ Code a, SingI code, Generic a, Alternative f)
+  :: (code ~ Code a, Generic a, Alternative f)
   => NP (ConstructorApplication f code) code -> f [a]
 produceAll = fmap catMaybes . sequenceA . map optional . produceM
 
 -- | Build a list of computations, one for each constructor in a data type.
 produceM
-  :: (code ~ Code a, SingI code, Generic a, Applicative f)
+  :: (code ~ Code a, Generic a, Applicative f)
   => NP (ConstructorApplication f code) code
   -> [f a]
 produceM fs =


### PR DESCRIPTION
I'm about to release generics-sop-0.2 today or within the next few days, which has a few interface changes.

As part of this process, I'm looking at a number of packages that depend on generics-sop, and see how their code is impacted by the change.

In the case of exhaustive, the changes are as follows:
- `SingI` has been deprecated and is now called `SListI`. However, in your case, `Generic` implies this constraint for both generics-sop-0.1 and generics-sop-0.2, so the constraint is redundant, and removing it means that the package will work with both versions.
